### PR TITLE
Use centing branch from dunst upstream

### DIFF
--- a/dunst/dunstrc
+++ b/dunst/dunstrc
@@ -29,7 +29,8 @@
     # the top and down respectively.
     # The width can be negative.  In this case the actual width is the
     # screen width minus the width defined in within the geometry option.
-    geometry = "500x5-1030+20"
+    geometry = "500x5-0+20"
+    centering = horizontal
 
     # Show how many messages are currently hidden (because of geometry).
     indicate_hidden = yes

--- a/service/dunst/run
+++ b/service/dunst/run
@@ -1,2 +1,7 @@
 #!/usr/bin/bash
-exec dunst 2>&1
+# Use a custom version of dunst, if we have built it
+if [ -x $HOME/src/void/dunst/dunst ] ; then
+  exec $HOME/src/void/dunst/dunst 2>&1
+else
+  exec dunst 2>&1
+fi


### PR DESCRIPTION
This allows me to center dunst notifications without relying on
the screen size
 
- [x] test on work box